### PR TITLE
Support CRLF line endings for DUCKY_LANG

### DIFF
--- a/applications/bad_usb/bad_usb_script.c
+++ b/applications/bad_usb/bad_usb_script.c
@@ -315,16 +315,16 @@ static int32_t ducky_parse_line(BadUsbScript* bad_usb, string_t line, const uint
 
 static uint16_t ducky_get_layout(const char* line) {
     uint16_t layout = 0;
-    if(strcmp(line, "US") == 0) {
+    if(strncmp(line, "US", 2) == 0) {
         layout = 0;
-    } else if(strcmp(line, "DE") == 0) {
+    } else if(strncmp(line, "DE", 2) == 0) {
         layout = 1;
-    } else if(strcmp(line, "FR") == 0) {
+    } else if(strncmp(line, "FR", 2) == 0) {
         layout = 2;
-    } else if(strcmp(line, "HU") == 0) {
+    } else if(strncmp(line, "HU", 2) == 0) {
         layout = 3;
     }
-    else if(strcmp(line, "BE") == 0){
+    else if(strncmp(line, "BE", 2) == 0){
         layout = 4;
     }
     FURI_LOG_D(WORKER_TAG, "keyboard layout set: %hu", layout);


### PR DESCRIPTION
# What's new

- DUCKY_LANG also works in files with CRLF line endings.

# Verification 

- Create test script with DUCKY_LANG that works with LF line endings but not CRLF with current version. Run same script with my version to confirm it works.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
